### PR TITLE
kombu rewrite

### DIFF
--- a/ceilometer_publisher_rabbitmq/queue.py
+++ b/ceilometer_publisher_rabbitmq/queue.py
@@ -39,7 +39,7 @@ class QueuePublisher(publisher.PublisherBase):
     def reconnect(self):
         """(re)connects to the configured rabbit server"""
         self.connection = kombu.Connection(
-            hostname     = +cfg.CONF.publisher_rabbit_host,
+            hostname     = cfg.CONF.publisher_rabbit_host,
             userid       = cfg.CONF.publisher_rabbit_user,
             password     = cfg.CONF.publisher_rabbit_password,
             virtual_host = cfg.CONF.publisher_rabbit_virtual_host,

--- a/ceilometer_publisher_rabbitmq/queue.py
+++ b/ceilometer_publisher_rabbitmq/queue.py
@@ -39,13 +39,14 @@ class QueuePublisher(publisher.PublisherBase):
     def reconnect(self):
         """(re)connects to the configured rabbit server"""
         self.connection = kombu.Connection(
-            hostname     = 'amqp://'+cfg.CONF.publisher_rabbit_host,
+            hostname     = +cfg.CONF.publisher_rabbit_host,
             userid       = cfg.CONF.publisher_rabbit_user,
             password     = cfg.CONF.publisher_rabbit_password,
             virtual_host = cfg.CONF.publisher_rabbit_virtual_host,
             port         = cfg.CONF.publisher_rabbit_port,
         )
-        self.channel = kombu.transport.pyamqp.Channel(self.connection)
+        self.connection.connect()
+        self.channel = self.connection.channel()
         self.exchange = kombu.Exchange(
             name        = cfg.CONF.publisher_exchange,
             type        = 'fanout',
@@ -56,8 +57,9 @@ class QueuePublisher(publisher.PublisherBase):
         self.exchange.declare()
 
         queue = kombu.Queue(
-            name = cfg.CONF.publisher_queue,
+            name     = cfg.CONF.publisher_queue,
             exchange = self.exchange,
+            channel  = self.channel,
         )
         queue.declare()
 

--- a/pkg/centos/ceilometer-publisher-rabbitmq.spec
+++ b/pkg/centos/ceilometer-publisher-rabbitmq.spec
@@ -1,5 +1,5 @@
 Name:           ceilometer-publisher-rabbitmq
-Version:        0.0.6
+Version:        0.0.7
 Release:        0anchor1%{?dist}
 Group:          Development/Libraries
 Summary:        A publisher plugin for Ceilometer that outputs to RabbitMQ
@@ -31,6 +31,9 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(-,root,root)
 
 %changelog
+
+* Mon Jan 19 2015 Oswyn Brent <oswyn.brent@anchor.net.au> - 0.0.7-0anchor1
+- Rewrite using kombu over pika
 
 * Tue Jan 13 2015 Barney Desmond <barney.desmond@anchor.net.au> - 0.0.6-0anchor1
 - Set explicit python-pika version requirement to avoid problems with 0.9.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 ceilometer
-pika
+kombu

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 setup(
     name="ceilometer-publisher-rabbitmq",
-    version="0.0.6",
+    version="0.0.7",
     description="A publisher plugin for Ceilometer that outputs to RabbitMQ",
     author="Oswyn Brent",
     author_email="oswyn.brent@anchor.com.au",

--- a/test_integration.py
+++ b/test_integration.py
@@ -67,5 +67,6 @@ def main(argv=None):
     else:
         print 'No messaged returned'
         sys.exit(1)
+
 if __name__ == '__main__':
     sys.exit(main())


### PR DESCRIPTION
There appears to be an issue in pika-0.9.14, as mentioned in #8, where channels can report that they are open but their socket is None.

Kombu's API is quite similar to pika, and so this change is really a minor tweak. While kombu has no ConnectionClosed or similar exception, its Connection.connected method reports correctly, so we simply check that instead of trying to catch an exception.