### PR TITLE
Disable confirm_publish to avoid simultaneous socket read in notificatio...

### DIFF
--- a/ceilometer_publisher_rabbitmq/queue.py
+++ b/ceilometer_publisher_rabbitmq/queue.py
@@ -45,7 +45,7 @@ class QueuePublisher(publisher.PublisherBase):
             virtual_host      = cfg.CONF.publisher_rabbit_virtual_host,
             port              = cfg.CONF.publisher_rabbit_port,
             transport_options = {
-                'confirm_publish' : True,
+                'confirm_publish' : False,
             },
         )
         self.connection.connect()


### PR DESCRIPTION
...n agent

This is a workaround to #16, caused by simultaneous reads on pyamqp's
global socket from multiple greenthreads in
ceilometer-notification-agent.

Should be reverted when a better fix is found.